### PR TITLE
Implement XP orb events

### DIFF
--- a/src/main/java/com/blamejared/clumps/Clumps.java
+++ b/src/main/java/com/blamejared/clumps/Clumps.java
@@ -1,6 +1,9 @@
 package com.blamejared.clumps;
 
 import com.blamejared.clumps.entities.EntityXPOrbBig;
+import com.blamejared.clumps.events.EXPCloneEvent;
+import com.blamejared.clumps.events.EXPMergeEvent;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.*;
 import net.minecraft.entity.item.ExperienceOrbEntity;
 import net.minecraft.world.World;
@@ -46,6 +49,8 @@ public class Clumps {
             ArrayList<ExperienceOrbEntity> list = new ArrayList<>(orbs);
             for(ExperienceOrbEntity entity : list) {
                 EntityXPOrbBig bigOrb = new EntityXPOrbBig(entity.getEntityWorld(), entity.getPosX(), entity.getPosY(), entity.getPosZ(), entity.xpValue);
+                MinecraftForge.EVENT_BUS.post(new EXPCloneEvent(entity, bigOrb));
+
                 bigOrb.setMotion(entity.getMotion());
                 entity.getEntityWorld().addEntity(bigOrb);
                 entity.remove();

--- a/src/main/java/com/blamejared/clumps/events/EXPCloneEvent.java
+++ b/src/main/java/com/blamejared/clumps/events/EXPCloneEvent.java
@@ -1,0 +1,32 @@
+package com.blamejared.clumps.events;
+
+import com.blamejared.clumps.entities.EntityXPOrbBig;
+import net.minecraft.entity.item.ExperienceOrbEntity;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * EXPCloneEvent is called when a vanilla XP orb is transformed into a Clumps
+ * {@link EntityXPOrbBig}. This provides the ability to transfer NBT data to the
+ * newly created entity if desired.
+ */
+public class EXPCloneEvent extends Event {
+    private final ExperienceOrbEntity vanillaOrb;
+    private EntityXPOrbBig newOrb;
+
+    public EXPCloneEvent(ExperienceOrbEntity vanillaOrb, EntityXPOrbBig newOrb) {
+        this.vanillaOrb = vanillaOrb;
+        this.newOrb = newOrb;
+    }
+
+    public ExperienceOrbEntity getVanillaOrb() {
+        return vanillaOrb;
+    }
+
+    public EntityXPOrbBig getNewOrb() {
+        return newOrb;
+    }
+
+    public void setNewOrb(EntityXPOrbBig newOrb) {
+        this.newOrb = newOrb;
+    }
+}

--- a/src/main/java/com/blamejared/clumps/events/EXPMergeEvent.java
+++ b/src/main/java/com/blamejared/clumps/events/EXPMergeEvent.java
@@ -1,0 +1,37 @@
+package com.blamejared.clumps.events;
+
+import com.blamejared.clumps.entities.EntityXPOrbBig;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * EXPMergeEvent is called when two Clumps {@link EntityXPOrbBig}s are combined
+ * into a new, bigger orb. Again, this allows for the transfer of any important NBT
+ * data from the old orbs to the new orb if necessary.
+ */
+public class EXPMergeEvent extends Event {
+    private final EntityXPOrbBig primaryOldOrb;
+    private final EntityXPOrbBig secondaryOldOrb;
+    private EntityXPOrbBig newOrb;
+
+    public EXPMergeEvent(EntityXPOrbBig primaryOldOrb, EntityXPOrbBig secondaryOldOrb, EntityXPOrbBig newOrb) {
+        this.primaryOldOrb = primaryOldOrb;
+        this.secondaryOldOrb = secondaryOldOrb;
+        this.newOrb = newOrb;
+    }
+
+    public EntityXPOrbBig getPrimaryOldOrb() {
+        return primaryOldOrb;
+    }
+
+    public EntityXPOrbBig getSecondaryOldOrb() {
+        return secondaryOldOrb;
+    }
+
+    public EntityXPOrbBig getNewOrb() {
+        return newOrb;
+    }
+
+    public void setNewOrb(EntityXPOrbBig newOrb) {
+        this.newOrb = newOrb;
+    }
+}


### PR DESCRIPTION
This commit adds two events, the EXPCloneEvent and the EXPMergeEvent. The former is called when a Vanilla XP orb is converted into a Clumps big orb, and the latter when two Clumps orbs are combined to create a new, bigger Clumps orb.

Fixes #28