### PR TITLE
Cleanup and Efficiency

### DIFF
--- a/src/main/java/com/blamejared/clumps/ClumpsClient.java
+++ b/src/main/java/com/blamejared/clumps/ClumpsClient.java
@@ -1,7 +1,6 @@
 package com.blamejared.clumps;
 
 import com.blamejared.clumps.client.render.RenderXPOrbBig;
-import com.blamejared.clumps.entities.EntityXPOrbBig;
 
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;


### PR DESCRIPTION
- Removed unnecessary imports
- Replaced multiple method calls to event bus with single reference
- Added injector for registry object over static initializer
- Lowered time complexity of replacement tick event from O(3n) to O(n)