### PR TITLE
Migrate to deferred register, safeRunWhenOn, add localization

### DIFF
--- a/src/main/java/com/blamejared/clumps/ClumpsClient.java
+++ b/src/main/java/com/blamejared/clumps/ClumpsClient.java
@@ -4,10 +4,14 @@ import com.blamejared.clumps.client.render.RenderXPOrbBig;
 
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 public class ClumpsClient {
+    protected static void register() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(ClumpsClient::setupClient);
+    }
 
     protected static void setupClient(FMLClientSetupEvent event) {
-        RenderingRegistry.registerEntityRenderingHandler(Clumps.BIG_ORB_ENTITY_TYPE, RenderXPOrbBig::new);
+        RenderingRegistry.registerEntityRenderingHandler(Clumps.BIG_ORB_ENTITY_TYPE.get(), RenderXPOrbBig::new);
     }
 }

--- a/src/main/java/com/blamejared/clumps/entities/EntityXPOrbBig.java
+++ b/src/main/java/com/blamejared/clumps/entities/EntityXPOrbBig.java
@@ -35,7 +35,7 @@ public class EntityXPOrbBig extends ExperienceOrbEntity implements IEntityAdditi
     private int clumpedOrbs;
     
     public EntityXPOrbBig(World worldIn, double x, double y, double z, int expValue, int clumpedOrbs) {
-        super(Clumps.BIG_ORB_ENTITY_TYPE, worldIn);
+        super(Clumps.BIG_ORB_ENTITY_TYPE.get(), worldIn);
         this.setPosition(x, y, z);
         this.rotationYaw = (float) (this.rand.nextDouble() * 360.0D);
         this.setMotion((this.rand.nextDouble() * (double) 0.2F - (double) 0.1F) * 2.0D, this.rand.nextDouble() * 0.2D * 2.0D, (this.rand.nextDouble() * (double) 0.2F - (double) 0.1F) * 2.0D);
@@ -44,13 +44,9 @@ public class EntityXPOrbBig extends ExperienceOrbEntity implements IEntityAdditi
     }
     
     public EntityXPOrbBig(EntityType<? extends ExperienceOrbEntity> type, World world) {
-        super(Clumps.BIG_ORB_ENTITY_TYPE, world);
+        super(type, world);
     }
-    
-    public EntityXPOrbBig(World world) {
-        super(Clumps.BIG_ORB_ENTITY_TYPE, world);
-    }
-    
+
     @Override
     public void tick() {
         if(!world.isRemote && this.xpValue == 0) {


### PR DESCRIPTION
- Replaced usage of ObjectHolder with DeferredRegister and RegistryObject
- Migrated from unsafeRunWhenOn to safeRunWhenOn for better class load safety
- Added localization deferral to the vanilla experience orb (fixes #52)

All changes have been tested, and function as intended.