### PR TITLE
Include dependency definitions for Forge and Minecraft in mods.toml

### DIFF
--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -13,9 +13,15 @@ authors="Jaredlll08"
 description='''
 Clumps xp orbs together.
 '''
-[[dependencies.clumps]]
-modId="forge"
-mandatory=true
-versionRange="[37.0.59,)"
-ordering="NONE"
-side="BOTH"
+  [[dependencies.clumps]]
+	modId="forge"
+	mandatory=true
+	versionRange="[37.0.59,)"
+	ordering="NONE"
+	side="BOTH"
+  [[dependencies.clumps]]
+    modId="minecraft"
+    mandatory=true
+    versionRange="[1.17.1,)"
+    ordering="NONE"
+    side="BOTH"


### PR DESCRIPTION
I noticed that your mods.toml is missing the dependency definition for Forge and Minecraft.

mods.toml need to specify their sideness so Minecraft/Forge knows whether the mod needs to be available on the client, the server, or both. If a mod uses the modId for dependencies.<value_of_modId>, it also helps with ServerPackCreator identifying clientside-only mods. [Reference issue #70](https://github.com/Griefed/ServerPackCreator/issues/70) of ServerPackCreator.

Let me know what you think. 👋

Cheers,
Griefed